### PR TITLE
Bump com.google.mlkit.barcode-scanning 17.0.1 to 17.0.2

### DIFF
--- a/barcodeScanning/build.gradle
+++ b/barcodeScanning/build.gradle
@@ -32,7 +32,7 @@ android {
 
 dependencies {
     implementation "com.google.code.gson:gson:$gson_version"
-    implementation 'com.google.mlkit:barcode-scanning:17.0.1'
+    implementation 'com.google.mlkit:barcode-scanning:17.0.2'
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'androidx.core:core-ktx:1.6.0'
     implementation "androidx.appcompat:appcompat:$app_compat_version"


### PR DESCRIPTION
I haven't yet gotten this working on Android so I'm unclear if this version bump works/helps